### PR TITLE
Resync forecast primitive state after driver-side updates

### DIFF
--- a/run_frigate_prediction.py
+++ b/run_frigate_prediction.py
@@ -441,8 +441,17 @@ def apply_ghost_zone_forcing(
     block_vars["hydro_u"] = clone_with_lateral_ghost_zones(
         block_vars["hydro_u"], target_hydro_u, nghost
     )
+    return synchronize_hydro_state(mesh, block_vars)
+
+
+def synchronize_hydro_state(
+    mesh: Mesh,
+    block_vars: dict[str, torch.Tensor],
+) -> dict[str, torch.Tensor]:
     eos = mesh.blocks[0].module("hydro.eos")
-    block_vars["hydro_w"] = eos.compute("U->W", (block_vars["hydro_u"],))
+    hydro_w = eos.compute("U->W", (block_vars["hydro_u"],))
+    mesh.blocks[0].apply_hydro_bc(hydro_w)
+    block_vars["hydro_w"] = hydro_w
     return block_vars
 
 def add_frigate_forcing(block_vars: dict[str, torch.Tensor],
@@ -503,7 +512,9 @@ def run_simulation(mesh: Mesh,
 
         for stage in range(len(intg.stages)):
             mesh.forward(mesh_vars, dt, stage)
+            block_vars = synchronize_hydro_state(mesh, block_vars)
             add_frigate_forcing(block_vars, eos, precip_indices, dt)
+            block_vars = synchronize_hydro_state(mesh, block_vars)
 
         err = mesh.check_redo(mesh_vars)
         if err > 0:
@@ -515,6 +526,7 @@ def run_simulation(mesh: Mesh,
             block_vars["hydro_w"], eos, thermo_x, thermo_y, kinet, dt
         )
         block_vars["hydro_u"][kICY:] += del_rho
+        block_vars = synchronize_hydro_state(mesh, block_vars)
 
         current_time += dt
         mesh.make_outputs(mesh_vars, current_time)

--- a/tests/test_run_frigate_prediction.py
+++ b/tests/test_run_frigate_prediction.py
@@ -185,6 +185,131 @@ def test_selected_topography_labels_for_no_refinement():
     assert module.selected_topography_labels("staged", None) == module.TOPO_SEQUENCE
 
 
+def test_run_simulation_resynchronizes_hydro_w_after_state_updates():
+    module = load_module()
+
+    class FakeIntegrator:
+        stages = (0,)
+
+        def stop(self, cycle, current_time):
+            return current_time >= 1.0
+
+    class FakeEOS:
+        def compute(self, op, args):
+            assert op == "U->W"
+            return args[0] + 100.0
+
+    class FakeCoord:
+        def nghost(self):
+            return 1
+
+    class FakeOptions:
+        class _IntgOptions:
+            def tlim(self, value):
+                self.value = value
+
+        def coord(self):
+            return FakeCoord()
+
+        def intg(self):
+            return self._IntgOptions()
+
+    class FakeBlock:
+        def __init__(self):
+            self._cycle = 0
+            self._options = FakeOptions()
+            self.eos = FakeEOS()
+
+        def module(self, name):
+            if name == "hydro.eos":
+                return self.eos
+            if name == "hydro.eos.thermo":
+                return object()
+            raise KeyError(name)
+
+        def cycle(self):
+            return self._cycle
+
+        def options(self):
+            return self._options
+
+        @property
+        def options(self):
+            return self._options
+
+        def apply_hydro_bc(self, hydro_w, type=0):
+            hydro_w[..., 0] += 1.0
+
+    class FakeMesh:
+        def __init__(self):
+            self.blocks = [FakeBlock()]
+            self.intg = FakeIntegrator()
+            self.output_snapshots = []
+
+        def module(self, name):
+            if name == "block0.intg":
+                return self.intg
+            raise KeyError(name)
+
+        def set_cycle(self, cycle):
+            self.blocks[0]._cycle = cycle
+
+        def max_time_step(self, mesh_vars):
+            return 1.0
+
+        def print_cycle_info(self, mesh_vars, current_time, dt):
+            pass
+
+        def forward(self, mesh_vars, dt, stage):
+            mesh_vars[0]["hydro_u"] = mesh_vars[0]["hydro_u"] + 2.0
+
+        def check_redo(self, mesh_vars):
+            return 0
+
+        def make_outputs(self, mesh_vars, current_time):
+            self.output_snapshots.append(
+                (
+                    current_time,
+                    mesh_vars[0]["hydro_u"].clone(),
+                    mesh_vars[0]["hydro_w"].clone(),
+                )
+            )
+
+    mesh = FakeMesh()
+    block_vars = {
+        "hydro_u": torch.zeros((6, 2, 2, 2), dtype=torch.float64),
+        "hydro_w": torch.zeros((6, 2, 2, 2), dtype=torch.float64),
+        "topo": torch.zeros((2, 2, 2), dtype=torch.bool),
+    }
+
+    original_add = module.add_frigate_forcing
+    original_evolve = module.evolve_kinetics
+    try:
+        module.add_frigate_forcing = (
+            lambda block_vars, eos, precip_indices, dt: block_vars["hydro_u"].add_(3.0)
+        )
+        module.evolve_kinetics = (
+            lambda hydro_w, eos, thermo_x, thermo_y, kinet, dt: torch.ones_like(hydro_w[module.kICY:])
+        )
+        mesh_vars, current_time = module.run_simulation(
+            mesh, object(), object(), [block_vars], 0.0, 1.0, ()
+        )
+    finally:
+        module.add_frigate_forcing = original_add
+        module.evolve_kinetics = original_evolve
+
+    assert current_time == 1.0
+    assert len(mesh.output_snapshots) == 1
+    _, hydro_u_out, hydro_w_out = mesh.output_snapshots[0]
+    expected_hydro_u = torch.full_like(hydro_u_out, 5.0)
+    expected_hydro_u[module.kICY:] += 1.0
+    assert torch.equal(hydro_u_out, expected_hydro_u)
+    expected_hydro_w = expected_hydro_u + 100.0
+    expected_hydro_w[..., 0] += 1.0
+    assert torch.equal(hydro_w_out, expected_hydro_w)
+    assert torch.equal(mesh_vars[0]["hydro_w"], expected_hydro_w)
+
+
 def test_run_staged_ghost_schedule_refines_at_06_and_12_only(monkeypatch):
     module = load_module()
     events = []


### PR DESCRIPTION
Keep hydro_w consistent with hydro_u in the forecast driver after Python-side source-term and ghost-zone modifications.

The snapy hydro solver updates primitive variables during its own hydrodynamic step, but run_frigate_prediction.py also mutates hydro_u outside that path when applying ghost forcing, FRIGATE forcing, and post-step kinetics updates. Those mutations left hydro_w stale for CFL estimation and NetCDF output, which produced runs with advancing time but frozen exported fields in both low-resolution and refined forecast modes.

Add a shared synchronize_hydro_state() helper that rebuilds hydro_w from hydro_u and reapplies hydro boundary conditions. Call it after ghost-zone refreshes and after each driver-side hydro_u mutation inside the common forecast timestepper.

Add a regression test that exercises run_simulation() with driver-side hydro_u updates and verifies outputs see the resynchronized primitive state rather than stale values.

Validated with:
- python -m pytest -q tests/test_run_frigate_prediction.py
- python -m pytest -q tests/test_forecast_prep.py tests/test_frigate_pipeline.py